### PR TITLE
Consolidate option libs and return unmount effects

### DIFF
--- a/lib/InteropUtils.js
+++ b/lib/InteropUtils.js
@@ -7,10 +7,25 @@ var updateJsPropFromOpt = function(obj, key) {
   }
 };
 
-// Provides: optFromJs
-var optFromJs = function(opt){
+// Provides: jsNullToOption
+var jsNullToOption = function(opt){
   return opt === null ? 0 : [0, opt]
 }
+
+// Provides: jsNullFromOption
+var jsNullFromOption = function(camlOpt) {
+  return camlOpt === 0 ? null : camlOpt[1];
+};
+
+// Provides: jsUndefinedFromOption
+var jsUndefinedFromOption = function(camlOpt) {
+  return camlOpt === 0 ? undefined : camlOpt[1];
+};
+
+// Provides: jsFromOptionMap
+var jsFromOptionMap = function(camlOpt, f) {
+  return camlOpt === 0 ? null : f(camlOpt[1]);
+};
 
 // Provides: setIfSome
 var setIfSome = function(obj, key, val) {

--- a/lib/React.js
+++ b/lib/React.js
@@ -44,27 +44,28 @@ var useReducer = function(reducer, initialState) {
   return caml_js_to_array(tuple);
 };
 
-// Provides: useEffect
-// Requires: React, caml_js_wrap_callback, optFromJs, caml_js_from_array
-var useEffect = function(effect, dependencies) {
-  var callback = caml_js_wrap_callback(effect);
-  var jsDeps = dependencies ? caml_js_from_array(dependencies) : undefined;
-  return React.useEffect(function() {
-    var opt = optFromJs(callback);
-    return opt === 0 ? null : caml_js_from_array(opt)[0];
-  }, jsDeps);
+// Provides: useEffectFunction
+// Requires: jsUndefinedFromOption, caml_js_from_array
+var useEffectFunction = function(effectFunction) {
+  return function(effect, dependencies) {
+    // Dependencies can be undefined for useEffect0
+    var jsDeps = dependencies ? caml_js_from_array(dependencies) : undefined;
+    return effectFunction(function() {
+      // No need to call caml_js_wrap_callback over `effect` or `unmount` as
+      // they don't have any arguments
+      var unmountEffect = effect();
+      return jsUndefinedFromOption(unmountEffect);
+    }, jsDeps);
+  };
 };
 
+// Provides: useEffect
+// Requires: React, useEffectFunction
+var useEffect = useEffectFunction(React.useEffect);
+
 // Provides: useLayoutEffect
-// Requires: React, caml_js_wrap_callback, optFromJs, caml_js_from_array
-var useLayoutEffect = function(effect, dependencies) {
-  var callback = caml_js_wrap_callback(effect);
-  var jsDeps = dependencies ? caml_js_from_array(dependencies) : undefined;
-  return React.useLayoutEffect(function() {
-    var opt = optFromJs(callback);
-    return opt === 0 ? null : caml_js_from_array(opt)[0];
-  }, jsDeps);
-};
+// Requires: React, useEffectFunction
+var useLayoutEffect = useEffectFunction(React.useLayoutEffect);
 
 // Provides: Ref_current
 // Requires: React
@@ -79,11 +80,11 @@ var Ref_setCurrent = React.setCurrent;
 var createRef = React.createRef;
 
 // Provides: forwardRef
-// Requires: React, caml_js_wrap_callback, optFromJs
+// Requires: React, caml_js_wrap_callback, jsNullToOption
 var forwardRef = function(callback) {
   var jsCallback = caml_js_wrap_callback(callback);
   return React.forwardRef(function(props, jsRef) {
-    var ref = optFromJs(jsRef);
+    var ref = jsNullToOption(jsRef);
     return jsCallback(props, jsRef);
   });
 };

--- a/lib/ReactDOM.js
+++ b/lib/ReactDOM.js
@@ -1,11 +1,6 @@
 // Provides: ReactDOM
 var ReactDOM = joo_global_object.ReactDOM;
 
-// Provides: fromOpt
-var fromOpt = function(camlOpt) {
-  return camlOpt === 0 ? null : camlOpt[1];
-};
-
 // Provides: render
 // Requires: ReactDOM
 var render = ReactDOM.render;
@@ -24,11 +19,11 @@ var domProps = function(key, ref, alt, async, className, onClick) {
 };
 
 // Provides: createDOMElementVariadic
-// Requires: React, fromOpt, caml_js_from_string, caml_js_from_array
+// Requires: React, jsNullFromOption, caml_js_from_string, caml_js_from_array
 var createDOMElementVariadic = function(string, props, children) {
   return React.createElement.apply(
     this,
-    [caml_js_from_string(string), fromOpt(props)].concat(
+    [caml_js_from_string(string), jsNullFromOption(props)].concat(
       caml_js_from_array(children)
     )
   );


### PR DESCRIPTION
This PR consolidates the conversion functions, as well as the effects into one function (as they were reusing most of it). Also solves the conversion from the effects returned value so the "unmount effect" is called too. Fixes #15.

@benschinn Merging this so it can be used for any other future effects work :) but please let me know if you see anything outstanding that should be taken care of, thanks!

