### PR TITLE
Experiment: Use Js_of_ocaml.Js to write bindings

### DIFF
--- a/lib/React.c
+++ b/lib/React.c
@@ -1,15 +1,5 @@
 #include <stdlib.h>
 #include <stdio.h>
-void nullElement () {
-  fprintf(stderr, "Unimplemented React function `nullElement`!\n");
-  exit(1);
-}
-
-void stringElement () {
-  fprintf(stderr, "Unimplemented React function `stringElement`!\n");
-  exit(1);
-}
-
 void createElement () {
   fprintf(stderr, "Unimplemented React function `createElement`!\n");
   exit(1);
@@ -22,16 +12,6 @@ void cloneElement () {
 
 void createElementVariadic () {
   fprintf(stderr, "Unimplemented React function `createElementVariadic`!\n");
-  exit(1);
-}
-
-void useState () {
-  fprintf(stderr, "Unimplemented React function `useState`!\n");
-  exit(1);
-}
-
-void useReducer () {
-  fprintf(stderr, "Unimplemented React function `useReducer`!\n");
   exit(1);
 }
 

--- a/lib/React.js
+++ b/lib/React.js
@@ -28,22 +28,6 @@ var createElementVariadic = function(component, props, children) {
   return React.createElement.apply(this, [component, props].concat(children));
 };
 
-// Provides: useState
-// Requires: React, caml_js_wrap_callback, caml_js_to_array
-var useState = function(initialState) {
-  var callback = caml_js_wrap_callback(initialState);
-  var tuple = React.useState(callback);
-  return caml_js_to_array(tuple);
-};
-
-// Provides: useReducer
-// Requires: React, caml_js_wrap_callback, caml_js_to_array
-var useReducer = function(reducer, initialState) {
-  var jsReducer = caml_js_wrap_callback(reducer);
-  var tuple = React.useReducer(jsReducer, initialState);
-  return caml_js_to_array(tuple);
-};
-
 // Provides: useEffectFunction
 // Requires: jsUndefinedFromOption, caml_js_from_array
 var useEffectFunction = function(effectFunction) {

--- a/lib/React.js
+++ b/lib/React.js
@@ -1,13 +1,6 @@
 // Provides: React
 var React = joo_global_object.React;
 
-// Provides: createElement
-// Requires: React, updateJsPropFromOpt
-var createElement = function(comp, props) {
-  updateJsPropFromOpt(props, "key");
-  return React.createElement(comp, props);
-};
-
 // Provides: cloneElement
 // Requires: React
 var cloneElement = React.cloneElement;

--- a/lib/React.js
+++ b/lib/React.js
@@ -1,15 +1,6 @@
 // Provides: React
 var React = joo_global_object.React;
 
-// Provides: nullElement
-var nullElement = function() {
-  return null;
-};
-
-// Provides: stringElement
-// Requires: caml_js_from_string
-var stringElement = caml_js_from_string;
-
 // Provides: createElement
 // Requires: React, updateJsPropFromOpt
 var createElement = function(comp, props) {

--- a/lib/React.re
+++ b/lib/React.re
@@ -6,14 +6,15 @@ class type react = {
     (Js.callback(('state, 'action) => 'state), 'state) =>
     Js.meth(Js.js_array('a));
 };
+
 let react: Js.t(react) = Js.Unsafe.global##.React;
 
 type element;
 
-external null: unit => element = "nullElement";
-let null = null();
+let null: element = Js.Unsafe.js_expr("null");
 
-external string: string => element = "stringElement";
+external jsStringToElement: Js.t(Js.js_string) => element = "%identity";
+let string = s => Js.string(s) |> jsStringToElement;
 
 external array: array(element) => element = "%identity";
 

--- a/lib/React.re
+++ b/lib/React.re
@@ -1,3 +1,13 @@
+open Js_of_ocaml;
+
+class type react = {
+  pub useState: Js.callback(unit => 'state) => Js.meth(Js.js_array('a));
+  pub useReducer:
+    (Js.callback(('state, 'action) => 'state), 'state) =>
+    Js.meth(Js.js_array('a));
+};
+let react: Js.t(react) = Js.Unsafe.global##.React;
+
 type element;
 
 external null: unit => element = "nullElement";
@@ -104,12 +114,21 @@ external forwardRef:
 
 /* HOOKS */
 
-external useState: (unit => 'state) => ('state, ('state => 'state) => unit) =
-  "useState";
+let useState = initialState => {
+  let callback = Js.wrap_callback(initialState);
+  let tuple = react##useState(callback);
+  let state: 'state = Js.Unsafe.get(tuple, 0);
+  let setState: ('state => 'state) => unit = Js.Unsafe.get(tuple, 1);
+  (state, setState);
+};
 
-external useReducer:
-  (('state, 'action) => 'state, 'state) => ('state, 'action => unit) =
-  "useReducer";
+let useReducer = (reducer, initialState) => {
+  let jsReducer = Js.wrap_callback(reducer);
+  let tuple = react##useReducer(jsReducer, initialState);
+  let state: 'state = Js.Unsafe.get(tuple, 0);
+  let dispatch: 'action => unit = Js.Unsafe.get(tuple, 1);
+  (state, dispatch);
+};
 
 external useEffect: (unit => option(unit => unit)) => unit = "useEffect";
 

--- a/lib/React.rei
+++ b/lib/React.rei
@@ -1,0 +1,57 @@
+type element;
+
+let null: element;
+let string: string => element;
+let array: array(element) => element;
+
+type component('props) = 'props => element;
+
+let createElement: (component('props), 'props) => element;
+let cloneElement: (component('props), 'props) => element;
+let createElementVariadic:
+  (component('props), 'props, array(element)) => element;
+
+module Ref: {
+  type t('value);
+  let current: t('value) => 'value;
+  let setCurrent: (t('value), 'value) => unit;
+};
+
+let createRef: unit => Ref.t(option('a));
+let forwardRef:
+  (('props, option(Ref.t('a))) => element) => component('props);
+
+let useState: (unit => 'state) => ('state, ('state => 'state) => unit);
+let useReducer:
+  (('state, 'action) => 'state, 'state) => ('state, 'action => unit);
+
+let useEffect: (unit => option(unit => unit)) => unit;
+let useEffect0: (unit => option(unit => unit), array(unit)) => unit;
+let useEffect1: (unit => option(unit => unit), array('a)) => unit;
+let useEffect2: (unit => option(unit => unit), ('a, 'b)) => unit;
+let useEffect3: (unit => option(unit => unit), ('a, 'b, 'c)) => unit;
+let useEffect4: (unit => option(unit => unit), ('a, 'b, 'c, 'd)) => unit;
+let useEffect5:
+  (unit => option(unit => unit), ('a, 'b, 'c, 'd, 'e)) => unit;
+let useEffect6:
+  (unit => option(unit => unit), ('a, 'b, 'c, 'd, 'e, 'f)) => unit;
+let useEffect7:
+  (unit => option(unit => unit), ('a, 'b, 'c, 'd, 'e, 'f, 'g)) => unit;
+
+let useLayoutEffect: (unit => option(unit => unit)) => unit;
+let useLayoutEffect0:
+  (unit => option(unit => unit), array(unit)) => unit;
+let useLayoutEffect1: (unit => option(unit => unit), array('a)) => unit;
+let useLayoutEffect2: (unit => option(unit => unit), ('a, 'b)) => unit;
+let useLayoutEffect3:
+  (unit => option(unit => unit), ('a, 'b, 'c)) => unit;
+let useLayoutEffect4:
+  (unit => option(unit => unit), ('a, 'b, 'c, 'd)) => unit;
+let useLayoutEffect5:
+  (unit => option(unit => unit), ('a, 'b, 'c, 'd, 'e)) => unit;
+let useLayoutEffect6:
+  (unit => option(unit => unit), ('a, 'b, 'c, 'd, 'e, 'f)) => unit;
+let useLayoutEffect7:
+  (unit => option(unit => unit), ('a, 'b, 'c, 'd, 'e, 'f, 'g)) => unit;
+
+let useRef: 'value => Ref.t('value);


### PR DESCRIPTION
As part of the discussion in #14 one idea was to write the bindings using jsoo `Js` module.

This PR explores the idea with a few functions. There is though a lot of unsafety and escape hatches, plus it requires knowing and understanding how all these `Js_of_ocaml.Js` functions and types work.

A couple of examples:
- Calling a method in an object has a type signature `'a => Js.meth('b)`. 😕 
- There are a lot of calls to `Js.Unsafe` to convert from Js values. For example when transforming the arrays returned from `useState` or `useReducer` to tuples. I don't think there is a safe way to do this conversion, or at least I couldn't find anything.

I am not sure this is the right path to follow. It seems to impose a much higher barrier of entry to potential contributors and the theoretical gains in safety are mostly gone due to the unavoidable unsafety in many cases.

@benschinn I wonder what your thoughts are? 🙂  