### PR TITLE
Fix deep elements (<Foo.bar />) tests

### DIFF
--- a/ppx/Rroo_jsoo_ppx.re
+++ b/ppx/Rroo_jsoo_ppx.re
@@ -1399,6 +1399,20 @@ let jsxMapper = () => {
           ),
         )
       }
+    /* This is just included because of the tests. We can't feed Reason-syntax code to the pp.expected tests.
+       So we feed OCaml code. But the generated Foo.make.createElement in OCaml code is parsed as Pexp_field */
+    | Pexp_field(
+        {pexp_desc: Pexp_ident({txt: modulePath}), pexp_loc: loc},
+        {txt: Lident("createElement")},
+      ) =>
+      transformUppercaseCall(
+        modulePath,
+        mapper,
+        loc,
+        attrs,
+        callExpression,
+        callArguments,
+      )
     | _ =>
       raise(
         Invalid_argument(

--- a/ppx/test/pp.expected
+++ b/ppx/test/pp.expected
@@ -76,9 +76,37 @@ let make =
             (Js_of_ocaml.Js.Unsafe.get t0 "b" : res)
         (Props : < .. >  Js_of_ocaml.Js.t)
         (fun ((x)[@merlin.loc ]) -> ((x#b)[@merlin.loc ])) in
-    Js.log "This function should be named `Test`";
+    print_endline "This function should be named `Test`";
     ReactDOM.createDOMElementVariadic "div" [||] in
   Test
+module External =
+  struct
+    let componentProps
+      : a:int ->
+          b:string ->
+            ?key:string ->
+              unit ->
+                <
+                  a: int Js_of_ocaml.Js.readonly_prop  ;b: string
+                                                             Js_of_ocaml.Js.readonly_prop
+                                                            > 
+                  Js_of_ocaml.Js.t
+      =
+      fun ~a ->
+        fun ~b ->
+          fun ?key ->
+            fun _ ->
+              let open Js_of_ocaml.Js.Unsafe in
+                obj
+                  [|("key", (inject key));("b", (inject b));("a", (inject a))|]
+    external component :
+      (<
+         a: int Js_of_ocaml.Js.readonly_prop  ;b: string
+                                                    Js_of_ocaml.Js.readonly_prop
+                                                   > 
+         Js_of_ocaml.Js.t,
+        React.element) React.componentLike = ""[@@otherAttribute "bla"]
+  end
 module Bar =
   struct
     let makeProps
@@ -122,7 +150,7 @@ module Bar =
                 (Js_of_ocaml.Js.Unsafe.get t5 "b" : res)
             (Props : < .. >  Js_of_ocaml.Js.t)
             (fun ((x)[@merlin.loc ]) -> ((x#b)[@merlin.loc ])) in
-        Js.log "This function should be named `Test$Bar`";
+        print_endline "This function should be named `Test$Bar`";
         ReactDOM.createDOMElementVariadic "div" [||] in
       Test$Bar
     let componentProps
@@ -166,7 +194,7 @@ module Bar =
                 (Js_of_ocaml.Js.Unsafe.get t3 "b" : res)
             (Props : < .. >  Js_of_ocaml.Js.t)
             (fun ((x)[@merlin.loc ]) -> ((x#b)[@merlin.loc ])) in
-        Js.log "This function should be named `Test$Bar$component`";
+        print_endline "This function should be named `Test$Bar$component`";
         ReactDOM.createDOMElementVariadic "div" [||] in
       Test$Bar$component
   end
@@ -215,7 +243,7 @@ module Func(M:X_int) =
                 (Js_of_ocaml.Js.Unsafe.get t7 "b" : res)
             (Props : < .. >  Js_of_ocaml.Js.t)
             (fun ((x)[@merlin.loc ]) -> ((x#b)[@merlin.loc ])) in
-        Js.log "This function should be named `Test$Func`" M.x;
+        print_endline "This function should be named `Test$Func`" M.x;
         ReactDOM.createDOMElementVariadic "div" [||] in
       Test$Func
   end
@@ -237,4 +265,21 @@ module ForwardRef =
              [|("ForwardRef" |. React.string)|] in
          Test$ForwardRef)
   end
-let fragment foo = ReactDOM.createFragment [|foo|]
+let fragment foo = ((ReactDOM.createFragment [|foo|])[@bla ])
+let polyChildrenFragment foo bar = ReactDOM.createFragment [|foo;bar|]
+let nestedFragment foo bar baz =
+  ReactDOM.createFragment [|foo;(ReactDOM.createFragment [|bar;baz|])|]
+let upper = React.createElement Upper.make (Upper.makeProps ())
+let upperWithChild foo =
+  React.createElement Upper.make (Upper.makeProps ~children:foo ())
+let upperWithChildren foo bar =
+  React.createElementVariadic Upper.make
+    (Upper.makeProps ~children:React.null ()) [|foo;bar|]
+let lower = ReactDOM.createDOMElementVariadic "lower" [||]
+let lowerWithChild foo = ReactDOM.createDOMElementVariadic "lower" [|foo|]
+let lowerWithChildren foo bar =
+  ReactDOM.createDOMElementVariadic "lower" [|foo;bar|]
+let nestedElement =
+  React.createElement Foo.Bar.make (Foo.Bar.makeProps ~a:1 ~b:"1" ())
+let nestedElementCustomName =
+  React.createElement Foo.component (Foo.componentProps ~a:1 ~b:"1" ())

--- a/ppx/test/test.ml
+++ b/ppx/test/test.ml
@@ -1,40 +1,71 @@
-let make ?(name= "")  =
-  (([((div ~children:[React.string ("Hello " ^ name)] ())
-    [@JSX ]);
-    ((Hello.createElement ~one:"1" ~children:[React.string ("Hello " ^ name)]
-        ())
-    [@JSX ])])
-  [@JSX ])[@@react.component ]
-let make ~a  ~b  _ =
-  Js.log "This function should be named `Test`";
-  ((div ~children:[] ())
-  [@JSX ])[@@react.component ]
-module Bar =
-  struct
-    let make ~a  ~b  _ =
-      Js.log "This function should be named `Test$Bar`";
-      ((div ~children:[] ())
-      [@JSX ])[@@react.component ]
-    let component ~a  ~b  _ =
-      Js.log "This function should be named `Test$Bar$component`";
-      ((div ~children:[] ())
-      [@JSX ])[@@react.component ]
-  end
-module type X_int  = sig val x : int end
-module Func(M:X_int) =
-  struct
-    let x = M.x + 1
-    let make ~a  ~b  _ =
-      Js.log "This function should be named `Test$Func`" M.x;
-      ((div ~children:[] ())
-      [@JSX ])[@@react.component ]
-  end
-module ForwardRef =
-  struct
-    let make =
-      React.forwardRef
-        (fun theRef ->
-           ((div ~ref:theRef ~children:["ForwardRef" |. React.string] ())
-           [@JSX ]))[@@react.component ]
-  end
-let fragment foo = (([foo])[@JSX ])
+let make ?(name = "") =
+  ([ (div ~children:[React.string ("Hello " ^ name)] () [@JSX])
+  ; (Hello.createElement ~one:"1" ~children:[React.string ("Hello " ^ name)] () 
+    [@JSX]) ] [@JSX])
+  [@@react.component]
+
+let make ~a ~b _ =
+  print_endline "This function should be named `Test`" ;
+  (div ~children:[] () [@JSX])
+  [@@react.component]
+
+module External = struct
+  external component : a:int -> b:string -> _ -> React.element = ""
+    [@@react.component] [@@otherAttribute "bla"]
+end
+
+module Bar = struct
+  let make ~a ~b _ =
+    print_endline "This function should be named `Test$Bar`" ;
+    (div ~children:[] () [@JSX])
+    [@@react.component]
+
+  let component ~a ~b _ =
+    print_endline "This function should be named `Test$Bar$component`" ;
+    (div ~children:[] () [@JSX])
+    [@@react.component]
+end
+
+module type X_int = sig
+  val x : int
+end
+
+module Func (M : X_int) = struct
+  let x = M.x + 1
+
+  let make ~a ~b _ =
+    print_endline "This function should be named `Test$Func`" M.x ;
+    (div ~children:[] () [@JSX])
+    [@@react.component]
+end
+
+module ForwardRef = struct
+  let make =
+    React.forwardRef (fun theRef ->
+        (div ~ref:theRef ~children:["ForwardRef" |. React.string] () [@JSX]) )
+    [@@react.component]
+end
+
+let fragment foo = ([foo] [@bla] [@JSX])
+
+let polyChildrenFragment foo bar = ([foo; bar] [@JSX])
+
+let nestedFragment foo bar baz = ([foo; ([bar; baz] [@JSX])] [@JSX])
+
+let upper = (Upper.createElement ~children:[] () [@JSX])
+
+let upperWithChild foo = (Upper.createElement ~children:[foo] () [@JSX])
+
+let upperWithChildren foo bar =
+  (Upper.createElement ~children:[foo; bar] () [@JSX])
+
+let lower = (lower ~children:[] () [@JSX])
+
+let lowerWithChild foo = (lower ~children:[foo] () [@JSX])
+
+let lowerWithChildren foo bar = (lower ~children:[foo; bar] () [@JSX])
+
+let nestedElement = (Foo.Bar.createElement ~a:1 ~b:"1" ~children:[] () [@JSX])
+
+let nestedElementCustomName =
+  (Foo.component.createElement ~a:1 ~b:"1" ~children:[] () [@JSX])

--- a/ppx/test/test_src.re
+++ b/ppx/test/test_src.re
@@ -17,28 +17,24 @@ let make = (~name="") => {
 
 [@react.component]
 let make = (~a, ~b, _) => {
-  Js.log("This function should be named `Test`");
+  print_endline("This function should be named `Test`");
   <div />;
 };
 
-/* Not supported yet, how does RR do it without matching against `Pexp_field`??? */
-/*
- module Foo = {
-   [@react.component] [@bs.module "Foo"]
-   external component: (~a: int, ~b: string, _) => React.element = "";
- };
- <Foo.component a=1 b="1" />;
- */
+module External = {
+  [@react.component] [@otherAttribute "bla"]
+  external component: (~a: int, ~b: string, _) => React.element = "";
+};
 
 module Bar = {
   [@react.component]
   let make = (~a, ~b, _) => {
-    Js.log("This function should be named `Test$Bar`");
+    print_endline("This function should be named `Test$Bar`");
     <div />;
   };
   [@react.component]
   let component = (~a, ~b, _) => {
-    Js.log("This function should be named `Test$Bar$component`");
+    print_endline("This function should be named `Test$Bar$component`");
     <div />;
   };
 };
@@ -49,7 +45,7 @@ module Func = (M: X_int) => {
   let x = M.x + 1;
   [@react.component]
   let make = (~a, ~b, _) => {
-    Js.log("This function should be named `Test$Func`", M.x);
+    print_endline("This function should be named `Test$Func`", M.x);
     <div />;
   };
 };
@@ -62,4 +58,27 @@ module ForwardRef = {
     );
 };
 
-let fragment = foo => <> foo </>;
+let fragment = foo => [@bla] <> foo </>;
+
+let polyChildrenFragment = (foo, bar) => <> foo bar </>;
+
+let nestedFragment = (foo, bar, baz) => <> foo <> bar baz </> </>;
+
+let upper = <Upper />;
+
+let upperWithChild = foo => <Upper> foo </Upper>;
+
+let upperWithChildren = (foo, bar) => <Upper> foo bar </Upper>;
+
+let lower = <lower />;
+
+let lowerWithChild = foo => <lower> foo </lower>;
+
+let lowerWithChildren = (foo, bar) => <lower> foo bar </lower>;
+
+let nestedElement = <Foo.Bar a=1 b="1" />;
+
+let nestedElementCustomName = <Foo.component a=1 b="1" />;
+
+// This throws exception (expected)
+// let lowerSpread = value => <lower> ...value </lower>;


### PR DESCRIPTION
This PR fixes an issue that was preventing the tests for elements that used deep accessors in the element function caller, like `<Foo.bar />` or `<Foo.Bar />`.

The issue was related to the tests running on OCaml syntax (due to ocaml-migrate-parsetree driver not supporting Reason syntax) and this made that the generated OCaml code for `<Foo.bar />` which transforms into `Foo.Bar.createElement`, being parsed as a `Pexp_field` expression.

Added also a lot of test cases for elements.